### PR TITLE
fix: release script, strict typing, and payout response unwrapping

### DIFF
--- a/packages/core/src/modules/payments.ts
+++ b/packages/core/src/modules/payments.ts
@@ -8,6 +8,7 @@ import {
   PauseStreamingPayload,
   PauseStreamingResponse,
   PaymentRequestData,
+  PayoutStatus,
   RequestAndPurchaseAssetRequestParams,
   RequestAndPurchaseAssetResponse,
   StartStreamingPayload,
@@ -54,7 +55,7 @@ export class PaymentsModule {
     token: string;
   }): Promise<{
     payoutId: string;
-    status: 'accepted' | 'rejected';
+    status: PayoutStatus;
     message: string;
     withdrawRequestId?: number;
     requestedAmount?: string;
@@ -62,8 +63,8 @@ export class PaymentsModule {
     createdAt: string;
     error?: string;
   }> {
-    const { data } = await this.client.post('/v1/payouts', params);
-    return data;
+    const resp = await this.client.post('/v1/payouts', params);
+    return resp.data.data;
   }
 
   /**

--- a/packages/core/src/modules/widget.ts
+++ b/packages/core/src/modules/widget.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosInstance } from 'axios';
+import { AxiosInstance, isAxiosError } from 'axios';
 import {
   GenerateOTPRequest,
   GenerateOTPResponse,
@@ -116,8 +116,7 @@ export class WidgetModule {
         currentIntervalMs = baseIntervalMs;
       } catch (err) {
         options.onError?.(err);
-        const ax = err as AxiosError<any>;
-        const status = ax.response?.status;
+        const status = isAxiosError(err) ? err.response?.status : undefined;
         // Fatal for invalid/missing reference keys: abort early
         if (status && [400, 401, 403, 404, 422].includes(status)) {
           return { paid: false, last };

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -57,7 +57,7 @@ export interface ApiResponse<T> {
   /** Error message when unsuccessful */
   error?: string;
   /** Additional error details */
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
   /** Request tracking ID for support */
   requestId?: string;
 }
@@ -153,7 +153,7 @@ export interface FilterParams extends PaginationParams, SortParams {
   /** Search query */
   search?: string;
   /** Additional custom filters */
-  filters?: Record<string, any>;
+  filters?: Record<string, unknown>;
 }
 
 /**
@@ -198,7 +198,7 @@ export interface WebhookPayload<T> {
 /**
  * Type guard to check if a value is a valid UUID
  */
-export function isUUID(value: any): value is UUID {
+export function isUUID(value: unknown): value is UUID {
   if (typeof value !== 'string') return false;
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return uuidRegex.test(value);
@@ -207,7 +207,7 @@ export function isUUID(value: any): value is UUID {
 /**
  * Type guard to check if a value is a valid money amount
  */
-export function isMoneyAmount(value: any): value is MoneyAmount {
+export function isMoneyAmount(value: unknown): value is MoneyAmount {
   if (typeof value !== 'string') return false;
   const moneyRegex = /^\d+(\.\d{1,2})?$/;
   return moneyRegex.test(value);

--- a/packages/core/src/types/enhanced-payment.ts
+++ b/packages/core/src/types/enhanced-payment.ts
@@ -117,7 +117,7 @@ export interface RequestPaymentPayload {
    * Custom metadata for your records
    * @description This data is returned in webhooks and payment queries
    */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 
   /**
    * Webhook URL for payment notifications
@@ -202,7 +202,7 @@ export interface PaymentSuccessResponse {
   invoiceId?: UUID;
 
   /** Custom metadata passed during payment creation */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -333,7 +333,7 @@ export interface IssuePaymentPayload {
     /** Client application ID */
     clientId?: string;
     /** Additional custom fields */
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/packages/core/src/types/enhanced-product.ts
+++ b/packages/core/src/types/enhanced-product.ts
@@ -168,7 +168,7 @@ export interface CreateProductPayload {
   /**
    * Custom metadata
    */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 
   /**
    * Product tags for search/filtering

--- a/packages/core/src/types/public.ts
+++ b/packages/core/src/types/public.ts
@@ -112,7 +112,7 @@ export interface ProductWithPrices {
   /** Array of image URLs for product display */
   images: string[];
   /** Flexible key-value data for additional product information */
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
   /** Associated price information (most recent active price) */
   prices: Array<{
     /** External UUID for API references */

--- a/packages/core/tests/payments.test.ts
+++ b/packages/core/tests/payments.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { BeepClient } from '../src';
+import { BeepClient, PayoutStatus } from '../src';
 
 describe('Payments Module', () => {
   let client: BeepClient;
@@ -126,17 +126,17 @@ describe('Payments Module', () => {
 
   describe('createPayout', () => {
     it('creates a payout successfully', async () => {
-      const mockResponse = {
+      const payoutData = {
         payoutId: 'payout_123',
-        status: 'accepted',
-        message: 'Payout accepted',
+        status: PayoutStatus.PENDING,
+        message: 'The request is being processed',
         withdrawRequestId: 42,
         requestedAmount: '1000000',
         reservedAmount: '1000000',
         createdAt: '2025-01-01T00:00:00Z',
       };
 
-      mockAxios.onPost('/v1/payouts').reply(200, mockResponse);
+      mockAxios.onPost('/v1/payouts').reply(200, { success: true, data: payoutData });
 
       const result = await client.payments.createPayout({
         amount: '1000000',
@@ -145,8 +145,8 @@ describe('Payments Module', () => {
         token: 'USDC',
       });
 
-      expect(result).toEqual(mockResponse);
-      expect(result.status).toBe('accepted');
+      expect(result).toEqual(payoutData);
+      expect(result.status).toBe(PayoutStatus.PENDING);
       const requestData = JSON.parse(mockAxios.history.post[0].data);
       expect(requestData.amount).toBe('1000000');
       expect(requestData.chain).toBe('SUI');

--- a/packages/core/tests/widget.test.ts
+++ b/packages/core/tests/widget.test.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { BeepPublicClient } from '../src';
+import { PayWayCode } from '../src/types/cash-payment';
 
 describe('Widget Module', () => {
   let client: BeepPublicClient;
@@ -144,7 +145,7 @@ describe('Widget Module', () => {
         reference: 'ref_123',
         walletAddress: '0xabc',
         amount: '50.00',
-        payWayCode: 10001 as any,
+        payWayCode: PayWayCode.VISA_MASTER_CARD,
         email: 'test@example.com',
       });
 

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -22,13 +22,7 @@ function updatePackageVersion(packagePath, version) {
   
   packageJson.version = version;
   
-  // Update workspace dependencies to use the new version
-  if (packageJson.dependencies && packageJson.dependencies['@beep-it/sdk-core']) {
-    packageJson.dependencies['@beep-it/sdk-core'] = `^${version}`;
-  }
-  if (packageJson.devDependencies && packageJson.devDependencies['@beep-it/sdk-core']) {
-    packageJson.devDependencies['@beep-it/sdk-core'] = `^${version}`;
-  }
+  // Skip workspace: protocol dependencies — pnpm resolves these automatically during publish
   
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
   console.log(`✅ Updated ${packagePath}/package.json to version ${version}`);


### PR DESCRIPTION
## Summary
- **Release script fix**: Stop replacing `workspace:^` protocol in `prepare-release.js` — pnpm handles this automatically during `npm publish`, and overwriting it breaks `--frozen-lockfile` in CI
- **Strict typing**: Replace all `Record<string, any>` with `Record<string, unknown>`, use `isAxiosError()` runtime guards instead of unsafe `as AxiosError` casts, and remove `as any` from tests
- **Payout response fix**: Unwrap the `{ success, data }` server envelope in `createPayout` so callers receive the actual payout object, and use `PayoutStatus` enum for the return type

## Test plan
- [ ] Verify `pnpm build` succeeds across all workspace packages
- [ ] Verify `pnpm test` passes (updated test mocks match real server envelope shape)
- [ ] Verify CI release pipeline works with unchanged `workspace:^` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)